### PR TITLE
Fixes _spacing typo

### DIFF
--- a/sass/_spacing.scss
+++ b/sass/_spacing.scss
@@ -142,7 +142,7 @@
 .mvl   { margin-top: 2rem;   margin-bottom: 2rem; }
 .mvx   { margin-top: 4rem;   margin-bottom: 4rem; }
 .mvxl  { margin-top: 8rem;   margin-bottom: 8rem; }
-.mvxl  { margin-top: 16rem;   margin-bottom: 16rem; }
+.mvxxl  { margin-top: 16rem; margin-bottom: 16rem; }
 
 .mhn   {  margin-left: 0;     margin-right: 0; }
 .mhs   {  margin-left: .5rem; margin-right: .5rem; }


### PR DESCRIPTION
You were missing an "x" in your "mvxxl".
