### PR TITLE
Use gulp-load-plugins to automatically require gulp plugins

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -1,16 +1,8 @@
 // Gulp tasks for Tachyons
 
-// Load plugins 
+// Load plugins
 var gulp = require('gulp'),
-    gutil = require('gulp-util'),
-    watch = require('gulp-watch'),
-    prefix = require('gulp-autoprefixer'),
-    uncss = require('gulp-uncss'),
-    minifyCSS = require('gulp-minify-css'),
-    sass = require('gulp-sass'),
-    size = require('gulp-size'),
-    rename = require('gulp-rename'),
-    csslint = require('gulp-csslint'),
+    plugins = require('gulp-load-plugins')(),
     browserSync = require('browser-sync'),
     browserReload = browserSync.reload;
 
@@ -19,25 +11,25 @@ var gulp = require('gulp'),
 // don't seem to be kept up to date on what to yell about)
 gulp.task('csslint', function(){
   gulp.src('./css/tachyons.css')
-    .pipe(csslint({
+    .pipe(plugins.csslint({
           'compatible-vendor-prefixes': false,
           'box-sizing': false,
           'important': false,
           'known-properties': false
         }))
-    .pipe(csslint.reporter());
+    .pipe(plugins.csslint.reporter());
 });
 
 // Task that compiles scss files down to good old css
 gulp.task('pre-process', function(){
   gulp.src('./sass/tachyons.scss')
-      .pipe(watch(function(files) {
-        return files.pipe(sass())
-          .pipe(size({gzip: false, showFiles: true, title:'un-prefixed uncompressed css'}))
-          .pipe(size({gzip: true, showFiles: true, title:'un-prefixed uncompressed css'}))
-          .pipe(prefix())
-          .pipe(size({gzip: false, showFiles: true, title:'prefixed uncompressed css'}))
-          .pipe(size({gzip: true, showFiles: true, title:'prefixed uncompressed css'}))
+      .pipe(plugins.watch(function(files) {
+        return files.pipe(plugins.sass())
+          .pipe(plugins.size({gzip: false, showFiles: true, title:'un-prefixed uncompressed css'}))
+          .pipe(plugins.size({gzip: true, showFiles: true, title:'un-prefixed uncompressed css'}))
+          .pipe(plugins.autoprefixer())
+          .pipe(plugins.size({gzip: false, showFiles: true, title:'prefixed uncompressed css'}))
+          .pipe(plugins.size({gzip: true, showFiles: true, title:'prefixed uncompressed css'}))
           .pipe(gulp.dest('css'))
           .pipe(browserSync.reload({stream:true}));
       }));
@@ -47,13 +39,13 @@ gulp.task('pre-process', function(){
 // Run this in the root directory of the project with `gulp minify-css `
 gulp.task('minify-css', function(){
   gulp.src('./css/tachyons.css')
-    .pipe(minifyCSS())
-    .pipe(rename('tachyons.min.css'))
+    .pipe(plugins.minifyCss())
+    .pipe(plugins.rename('tachyons.min.css'))
     .pipe(gulp.dest('./css/'))
-    .pipe(size({gzip: true, showFiles: true, title:'minified css'}));
+    .pipe(plugins.size({gzip: true, showFiles: true, title:'minified css'}));
 });
 
-// Initialize browser-sync which starts a static server also allows for 
+// Initialize browser-sync which starts a static server also allows for
 // browsers to reload on filesave
 gulp.task('browser-sync', function() {
     browserSync.init(null, {

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "gulp": "^3.8.2",
     "gulp-autoprefixer": "0.0.7",
     "gulp-csslint": "^0.1.4",
+    "gulp-load-plugins": "^0.6.0",
     "gulp-minify-css": "^0.3.5",
     "gulp-rename": "^1.2.0",
     "gulp-sass": "^0.7.2",


### PR DESCRIPTION
gulp-load-plugins automatically requires gulp plugins specified in package.json. That makes it easier to add and remove plugins in the future. For further information on gulp-load-plugins see: https://www.npmjs.org/package/gulp-load-plugins
