### PR TITLE
Added _opacity import

### DIFF
--- a/src/tachyons.css
+++ b/src/tachyons.css
@@ -38,6 +38,7 @@
 @import './_widths';
 @import './_overflow';
 @import './_position';
+@import './_opacity';
 @import './_skins';
 @import './_spacing';
 @import './_text-decoration';


### PR DESCRIPTION
Opacity file import was missing from tachyons.css. If there is a reason for this, ignore this commit, but perhaps document the reason somewhere (or leave the import and comment it out).

Rebuild should also be done as the opacity classes are also missing from the build. 