### PR TITLE
Update tachyons-modules to include skins

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "immutable-css-cli": "^1.1.1",
     "normalize.css": "^4.0.0",
     "tachyons-cli": "^0.6.0",
-    "tachyons-modules": "^1.0.3",
+    "tachyons-modules": "^1.1.0",
     "watch": "^0.17.1"
   },
   "contributors": [


### PR DESCRIPTION
Before, the tachyons-skins module was being ignored
while colors were being reworked. Now that it has been,
it's time to add it back to the build process.