### PR TITLE
Use variables for type scale

### DIFF
--- a/src/_type-scale.css
+++ b/src/_type-scale.css
@@ -27,64 +27,75 @@
  * so be careful using them on smaller screens.
  * */
 
+:root {
+  --type-extra-small: .875rem;
+  --type-small: 1rem;
+  --type-medium: 1.25rem;
+  --type-large: 1.5rem;
+  --type-extra-large: 2.25rem;
+  --type-extra-extra-large: 3rem;
+  --type-subheadline: 5rem;
+  --type-headline: 6rem;
+}
+
 .f-6,
 .f-headline {
-  font-size: 6rem;
+  font-size: var(--type-headline);
 }
 .f-5,
 .f-subheadline {
-  font-size: 5rem;
+  font-size: var(--type-subheadline);
 }
 
 
 /* Type Scale */
 
-.f1 { font-size: 3rem; }
-.f2 { font-size: 2.25rem; }
-.f3 { font-size: 1.5rem; }
-.f4 { font-size: 1.25rem; }
-.f5 { font-size: 1rem; }
-.f6 { font-size: .875rem; }
+.f1 { font-size: var(--type-extra-extra-large); }
+.f2 { font-size: var(--type-extra-large); }
+.f3 { font-size: var(--type-large); }
+.f4 { font-size: var(--type-medium); }
+.f5 { font-size: var(--type-small); }
+.f6 { font-size: var(--type-extra-small); }
 
 @media (--breakpoint-not-small){
   .f-6-ns,
-  .f-headline-ns { font-size: 6rem; }
+  .f-headline-ns { font-size: var(--type-headline); }
   .f-5-ns,
-  .f-subheadline-ns { font-size: 5rem; }
-  .f1-ns { font-size: 3rem; }
-  .f2-ns { font-size: 2.25rem; }
-  .f3-ns { font-size: 1.5rem; }
-  .f4-ns { font-size: 1.25rem; }
-  .f5-ns { font-size: 1rem; }
-  .f6-ns { font-size: .875rem; }
+  .f-subheadline-ns { font-size: var(--type-subheadline); }
+  .f1-ns { font-size: var(--type-extra-extra-large); }
+  .f2-ns { font-size: var(--type-extra-large); }
+  .f3-ns { font-size: var(--type-large); }
+  .f4-ns { font-size: var(--type-medium); }
+  .f5-ns { font-size: var(--type-small); }
+  .f6-ns { font-size: var(--type-extra-small); }
 }
 
 @media (--breakpoint-medium) {
   .f-6-m,
-  .f-headline-m { font-size: 6rem; }
+  .f-headline-m { font-size: var(--type-headline); }
   .f-5-m,
-  .f-subheadline-m { font-size: 5rem; }
-  .f1-m { font-size: 3rem; }
-  .f2-m { font-size: 2.25rem; }
-  .f3-m { font-size: 1.5rem; }
-  .f4-m { font-size: 1.25rem; }
-  .f5-m { font-size: 1rem; }
-  .f6-m { font-size: .875rem; }
+  .f-subheadline-m { font-size: var(--type-subheadline); }
+  .f1-m { font-size: var(--type-extra-extra-large); }
+  .f2-m { font-size: var(--type-extra-large); }
+  .f3-m { font-size: var(--type-large); }
+  .f4-m { font-size: var(--type-medium); }
+  .f5-m { font-size: var(--type-small); }
+  .f6-m { font-size: var(--type-extra-small); }
 }
 
 @media (--breakpoint-large) {
   .f-6-l,
   .f-headline-l {
-    font-size: 6rem;
+    font-size: var(--type-headline);
   }
   .f-5-l,
   .f-subheadline-l {
-    font-size: 5rem;
+    font-size: var(--type-subheadline);
   }
-  .f1-l { font-size: 3rem; }
-  .f2-l { font-size: 2.25rem; }
-  .f3-l { font-size: 1.5rem; }
-  .f4-l { font-size: 1.25rem; }
-  .f5-l { font-size: 1rem; }
-  .f6-l { font-size: .875rem; }
+  .f1-l { font-size: var(--type-extra-extra-large); }
+  .f2-l { font-size: var(--type-extra-large); }
+  .f3-l { font-size: var(--type-large); }
+  .f4-l { font-size: var(--type-medium); }
+  .f5-l { font-size: var(--type-small); }
+  .f6-l { font-size: var(--type-extra-small); }
 }


### PR DESCRIPTION
This commit is identical to #326, except with a cleaner commit history and without touching extraneous files. Here's the description from that PR:

> The benefits of this are two-fold:
>
> 1. It makes things a little DRYer.
> 2. It makes things easier to customize when using a PostCSS build flow. If you `@import` the Tachyons file from `src/`, you can simply update the type-scale variables and the new values will be reflected on build.
>
> I left space for a `--type-extra-extra-small` variable in the event the `.f7` class that has been discussed makes its way into the codebase.