### PR TITLE
Add .darken class for darkening background of elements on hover.

### DIFF
--- a/src/_hovers.css
+++ b/src/_hovers.css
@@ -33,6 +33,20 @@
 
 /*
 
+  Darken element background on hover by adding the darken class.
+
+*/
+.darken:hover,
+.darken:focus {
+  box-shadow: inset 9999px 9999px rgba(0,0,0,0.10)
+}
+
+.darken:active {
+  box-shadow: inset 9999px 9999px rgba(0,0,0,0.20)
+}
+
+/*
+
   Animate opacity to 100% on hover by adding the glow class.
 
 */
@@ -117,11 +131,11 @@
   cursor: pointer;
 }
 
-/* 
+/*
    Add shadow on hover.
 
-   Performant box-shadow animation pattern from 
-   http://tobiasahlin.com/blog/how-to-animate-box-shadow/ 
+   Performant box-shadow animation pattern from
+   http://tobiasahlin.com/blog/how-to-animate-box-shadow/
 */
 
 .shadow-hover {
@@ -148,12 +162,12 @@
   opacity: 1;
 }
 
-/* Combine with classes in skins and skins-pseudo for 
+/* Combine with classes in skins and skins-pseudo for
  * many different transition possibilities. */
 
 .bg-animate,
 .bg-animate:hover,
 .bg-animate:focus {
-  transition: background-color .15s ease-in-out; 
+  transition: background-color .15s ease-in-out;
 }
 


### PR DESCRIPTION
Darkening the background of buttons is pretty standard across the web (Bootstrap, Semantic UI, etc.). Using an inset box shadow is a clever way of darkening the background of buttons regardless of their background color without having to specify a specific background hover color.

I've actually created a couple of different classes (e.g. `darken-05`, `darken-10`) in the same vein as their are both `grow` and `grow-large` classes, but felt I'd limit this pull request to a single class for simplicity. Open to adding more if it's deemed useful...

Here a quick JSFiddle example:

https://jsfiddle.net/ejj32vxh/

You can see in the above example why it might be nice to have two (or more) darken classes -- for blue backgrounds or other darken backgrounds, `darken-10` works well, but for white and transparent backgrounds, `darken-10` seems like a little much.