### PR TITLE
Renaming the main file not to be minified

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,7 +1,7 @@
 {
   "name": "tachyons",
   "description": "Functional CSS for humans",
-  "main": "css/tachyons.min.css",
+  "main": "css/tachyons.css",
   "authors": [
     "mrmrs"
   ],


### PR DESCRIPTION
Preventing the warning:

`'The "main" field cannot contain minified files'`

From -
 https://github.com/bower/bower/blob/d405917b4a6efdeeb24a2087680fd4163896ab8e/packages/bower-json/lib/json.js#L180-L182

as per issue raised https://github.com/tachyons-css/tachyons/issues/364