### PR TITLE
Correct .hover-bg-mid-gray:focus rule

### DIFF
--- a/src/_skins-pseudo.css
+++ b/src/_skins-pseudo.css
@@ -75,8 +75,8 @@
 .hover-bg-near-black:focus { background-color: var(--near-black); }
 .hover-bg-dark-gray:hover, 
 .hover-bg-dark-gray:focus { background-color: var(--dark-gray); }
-.hover-bg-mid-gray:focus, 
-.hover-bg-mid-gray:hover { background-color: var(--mid-gray); }
+.hover-bg-mid-gray:hover, 
+.hover-bg-mid-gray:focus { background-color: var(--mid-gray); }
 .hover-bg-gray:hover, 
 .hover-bg-gray:focus { background-color: var(--gray); }
 .hover-bg-silver:hover, 

--- a/src/_skins-pseudo.css
+++ b/src/_skins-pseudo.css
@@ -75,7 +75,7 @@
 .hover-bg-near-black:focus { background-color: var(--near-black); }
 .hover-bg-dark-gray:hover, 
 .hover-bg-dark-gray:focus { background-color: var(--dark-gray); }
-.hover-bg-dark-gray:focus, 
+.hover-bg-mid-gray:focus, 
 .hover-bg-mid-gray:hover { background-color: var(--mid-gray); }
 .hover-bg-gray:hover, 
 .hover-bg-gray:focus { background-color: var(--gray); }


### PR DESCRIPTION
Spotted a small error in `_skins-pseudo` where `.hover-bg-dark-gray:focus` was redefined with the `--mid-gray`variable instead of defining `.hover-bg-mid-gray:focus`

I also swapped the rules to maintain consistency with the rest of the file. 