### PR TITLE
Add border-radius: inherit to shadow hover effect

### DIFF
--- a/src/_hovers.css
+++ b/src/_hovers.css
@@ -133,6 +133,7 @@
 .shadow-hover::after {
   content: '';
   box-shadow: 0px 0px 16px 2px rgba( 0, 0, 0, .2 );
+  border-radius: inherit;
   opacity: 0;
   position: absolute;
   top: 0;


### PR DESCRIPTION
Add `border-radius: inherit` to `.shadow-hover::after` to avoid ghost corners on elements with large rounded corners.
<img width="276" alt="screen shot 2017-06-13 at 8 58 47 am" src="https://user-images.githubusercontent.com/13597875/27093093-4adc74a2-501a-11e7-88e3-aef2f720bacc.png">
