### PR TITLE
Add missing word-break module

### DIFF
--- a/src/tachyons.css
+++ b/src/tachyons.css
@@ -75,6 +75,7 @@
 @import './_utilities';
 @import './_visibility';
 @import './_white-space';
+@import './_word-break';
 @import './_vertical-align';
 @import './_hovers';
 @import './_z-index';


### PR DESCRIPTION
Word-break is the only tachyons module present in sources but not included in build css.