### PR TITLE
Move Segoe UI above helvetica in sans-serif stack

### DIFF
--- a/src/_font-family.css
+++ b/src/_font-family.css
@@ -9,10 +9,11 @@
 .sans-serif {
   font-family: -apple-system, BlinkMacSystemFont,
                'avenir next', avenir,
+               'segoe ui',
                'helvetica neue', helvetica,
                ubuntu,
                roboto, noto,
-               'segoe ui', arial,
+               arial,
                sans-serif;
 }
 


### PR DESCRIPTION
Move Segoe UI above Helvetica as Windows aliases Helvetica to Arial. Presumably would prefer Segoe UI over Arial.