### PR TITLE
Adding DC Design Week to featured sites

### DIFF
--- a/sites.md
+++ b/sites.md
@@ -88,3 +88,4 @@
 * http://www.spokesman.com/
 * https://enveloop.studio
 * http://tylerdeitz.com
+* https://www.dcdesignweek.org/


### PR DESCRIPTION
Hello!

I'd like to submit the website for DC Design Week (DCDW) to the list of featured sites. There are some custom styles added, but the bulk of the site is utilizing Tachyons.

> Background info on DCDW:
> DC Design Week is led and produced by AIGA DC, the local chapter of the professional association for design. AIGA advances design as a professional craft, strategic advancement, and vital cultural force.
> 
> The DC chapter was founded in 1984, and is run by a volunteer board of directors. With over 1,230 members, AIGA DC is the fifth largest and one of the oldest chapters in the nation. We strive to cultivate, connect and celebrate the diverse work and people that make up our DC creative community.

Let me know if there is anything else I need to do!

Thanks,
Marcus