### PR TITLE
Add Play.cash as a featured site

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -117,6 +117,7 @@ We love letting the community see what people are building so please add your li
 * https://purple3.herokuapp.com
 * http://blunt.af/tachy.app/
 * https://fenderdigital.github.io/css-utilities/intro/
+* https://play.cash
 
 And of course...
 * http://tachyons.io


### PR DESCRIPTION
Just realized that my site (https://play.cash) wasn't on the list!