### PR TITLE
Improve interactive examples

### DIFF
--- a/docs/ui/Examples.js
+++ b/docs/ui/Examples.js
@@ -1,5 +1,6 @@
 import React, { Component } from 'react'
 import Highlight from 'react-highlight'
+import classNames from 'classnames'
 import he from 'he'
 
 const replace = (str, replace) => str.replace(/{{EXAMPLE}}/g, replace)
@@ -16,32 +17,42 @@ class Examples extends Component {
   }
 
   render() {
-    const html = replace(this.props.html, this.state.current)
+    const { current, html } = this.state
+    const code = replace(this.props.html, this.state.current)
 
     return (
-      <div>
+      <div className="sans-serif">
+        <h6 className="mid-gray f7 ttu tracked mt0 mb2">Examples</h6>
         <div
-          className="mb3"
-          children={this.props.examples.map(example => (
-            <span
-              key={example}
-              className="pv1 ph2 mr3 f7 fw6 ba b--black-30 mid-gray bg-white sans-serif pointer"
-              onClick={() => {
-                this.handleChange(example)
-              }}
-              children={example}
-            />
-          ))}
+          className="mb3 pointer"
+          children={this.props.examples.map(example => {
+            const isActive = example === current
+            const cx = classNames('pv1 ph2 mr3 f7 fw6 ba', {
+              'b--black-30 mid-gray bg-white dim': !isActive,
+              'b--black white bg-black': isActive
+            })
+
+            return (
+              <span
+                key={example}
+                className={cx}
+                onClick={() => {
+                  this.handleChange(example)
+                }}
+                children={example}
+              />
+            )
+          })}
         />
 
         <div
           className="sans-serif ws-normal"
           dangerouslySetInnerHTML={{
-            __html: he.decode(html)
+            __html: he.decode(code)
           }}
         />
 
-        <Highlight innerHtml={true} children={html} />
+        <Highlight innerHtml={true} children={code} />
       </div>
     )
   }


### PR DESCRIPTION
This makes it more apparent that the examples are
indeed interactive and adds active and hover states.

***

![screenshot 2018-03-13 06 56 17_preview](https://user-images.githubusercontent.com/1424573/37343025-ef8b6ba0-268b-11e8-90de-3b518a6ce8a5.png)
