### PR TITLE
Moving all .bg-* classes into Background colors

### DIFF
--- a/css/tachyons.css
+++ b/css/tachyons.css
@@ -1126,6 +1126,7 @@ code, .code { font-family: Consolas, monaco, monospace; }
 .washed-yellow { color: #fffceb; }
 .washed-red { color: #ffdfdf; }
 .color-inherit { color: inherit; }
+/* Background colors */
 .bg-black-90 { background-color: rgba( 0, 0, 0, .9 ); }
 .bg-black-80 { background-color: rgba( 0, 0, 0, .8 ); }
 .bg-black-70 { background-color: rgba( 0, 0, 0, .7 ); }
@@ -1145,7 +1146,6 @@ code, .code { font-family: Consolas, monaco, monospace; }
 .bg-white-30 { background-color: rgba( 255, 255, 255, .3 ); }
 .bg-white-20 { background-color: rgba( 255, 255, 255, .2 ); }
 .bg-white-10 { background-color: rgba( 255, 255, 255, .1 ); }
-/* Background colors */
 .bg-black { background-color: #000; }
 .bg-near-black { background-color: #111; }
 .bg-dark-gray { background-color: #333; }

--- a/src/_skins.css
+++ b/src/_skins.css
@@ -71,6 +71,10 @@
 .washed-red { color: var(--washed-red); }
 .color-inherit { color: inherit; }
 
+
+
+/* Background colors */
+
 .bg-black-90 {         background-color: var(--black-90); }
 .bg-black-80 {         background-color: var(--black-80); }
 .bg-black-70 {         background-color: var(--black-70); }
@@ -90,10 +94,6 @@
 .bg-white-30 {        background-color: var(--white-30); }
 .bg-white-20 {        background-color: var(--white-20); }
 .bg-white-10 {        background-color: var(--white-10); }
-
-
-
-/* Background colors */
 
 .bg-black {         background-color: var(--black); }
 .bg-near-black {    background-color: var(--near-black); }


### PR DESCRIPTION
When using Tachyons I noticed that all of the `.bg-black-*` and `.bg-white-*` classes were not grouped under the `/* Background colors */` section. I moved them down and matched them to the ordering in the `/* Text colors */` section, while preserving the same empty line schema.