### PR TITLE
Improve the .hide-child to work with absolute positioned .child elements

### DIFF
--- a/src/_hovers.css
+++ b/src/_hovers.css
@@ -62,13 +62,15 @@
 
 .hide-child .child {
   opacity: 0;
-  transition: opacity .15s ease-in;
+  visibility: hidden;
+  transition: opacity .15s ease-in, visibility .15s ease-in;
 }
 .hide-child:hover  .child,
 .hide-child:focus  .child,
 .hide-child:active .child {
   opacity: 1;
-  transition: opacity .15s ease-in;
+  visibility: visible;
+  transition: opacity .15s ease-in, visibility .15s ease-in;
 }
 
 .underline-hover:hover,
@@ -117,11 +119,11 @@
   cursor: pointer;
 }
 
-/* 
+/*
    Add shadow on hover.
 
-   Performant box-shadow animation pattern from 
-   http://tobiasahlin.com/blog/how-to-animate-box-shadow/ 
+   Performant box-shadow animation pattern from
+   http://tobiasahlin.com/blog/how-to-animate-box-shadow/
 */
 
 .shadow-hover {
@@ -149,12 +151,11 @@
   opacity: 1;
 }
 
-/* Combine with classes in skins and skins-pseudo for 
+/* Combine with classes in skins and skins-pseudo for
  * many different transition possibilities. */
 
 .bg-animate,
 .bg-animate:hover,
 .bg-animate:focus {
-  transition: background-color .15s ease-in-out; 
+  transition: background-color .15s ease-in-out;
 }
-


### PR DESCRIPTION
This is related to: #423

Currently, the `.hide-child` class visually hides the `.child` element using the `opacity` property. While this works well with static/relative elements it does not work if the child element is absolute/fixed. 

When moving the mouse pointer below where the `.child` element would appear, it triggers the `hover` state. This is particularly problematic when creating a tooltip-like component.

Both of the proposed solutions in the [first](
https://github.com/tachyons-css/tachyons/issues/423#issue-255555310) and [last](
https://github.com/tachyons-css/tachyons/issues/423#issuecomment-333084082) comment of #423 make too many assumptions about the styling and the position of the child element. Using the property `display: block/none` breaks the fade transition and the last comment just adds unnecessary properties such as `width` and `height`.

My proposed approach is to simply set the `visibility` property to indicate to the browser engine that the element is actually hidden and should not be interacted with. This prevents the mouse pointer from interacting with `.child` element. It does not break the fade in/out transition and is making as little assumptions about the styling of the parent and child elements as possible.

To ensure this does not break anything, I've created a [simple demo](https://codepen.io/pbobak/pen/RvKjXb) along with the card example from the documentation. 

I have tested it in the latest releases of Safari, Chrome and Firefox (Interestingly, only Firefox seem to disable mouse interactions on elements that have the opacity set to 0)

P.S. My code editor has also removed any trailing whitespace in file.