### PR TITLE
Expand font-size scale, rename classes for clarity

### DIFF
--- a/css/tachyons.css
+++ b/css/tachyons.css
@@ -875,7 +875,7 @@ http://tachyons.io/docs/typography/font-style/
 ### Base
 
 - i = italic
-- fs-normal = normal
+- fstyle-normal = normal
 
 ### Media Query Extensions
 
@@ -884,7 +884,7 @@ http://tachyons.io/docs/typography/font-style/
 - `-l` = large
 */
 .i { font-style: italic; }
-.fs-normal { font-style: normal; }
+.fstyle-normal { font-style: normal; }
 /*!!!
 
 # FONT WEIGHT
@@ -2554,19 +2554,20 @@ http://tachyons.io/docs/typography/scale/
 
 ### Base
 
-- f = font-size
+- fs = font-size
 
 ### Modifiers
 
-- 1 = 1st step back in size scale
-- 2 = 2nd step back in size scale
-- 3 = 3rd step back in size scale
-- 4 = 4th step back in size scale
-- 5 = 5th step back in size scale
-- 6 = 6th step back in size scale
-- 7 = 7th step back in size scale
-- 8 = 8th step back in size scale
-- 0 = Extra large
+- 1 = 1st step in size scale
+- 2 = 2nd step in size scale
+- 3 = 3rd step in size scale
+- 4 = 4th step in size scale
+- 5 = 5th step in size scale
+- 6 = 6th step in size scale
+- 7 = 7th step in size scale
+- 8 = 8th step in size scale
+- 9 = 9th step in size scale
+- 10 = 10th step in size scale
 
 ### Media Query Extensions
 
@@ -2575,15 +2576,16 @@ http://tachyons.io/docs/typography/scale/
 - `-l` = large
 */
 /* Type Scale */
-.f0 { font-size: 6rem; }
-.f1 { font-size: 4rem; }
-.f2 { font-size: 3rem; }
-.f3 { font-size: 2rem; }
-.f4 { font-size: 1.5rem; }
-.f5 { font-size: 1rem; }
-.f6 { font-size: .875rem; }
-/* Small and hard to read for many people so use with extreme caution */
-.f7 { font-size: .75rem; }
+.fs1 { font-size: .75rem; } /* Small and may be hard to read. Use with caution. */
+.fs2 { font-size: .875rem; }
+.fs3 { font-size: 1rem; }
+.fs4 { font-size: 1.25rem; }
+.fs5 { font-size: 1.5rem; }
+.fs6 { font-size: 2.25rem; }
+.fs7 { font-size: 3rem; }
+.fs8 { font-size: 4rem; }
+.fs9, .fs-subheadline { font-size: 5rem; }
+.fs10, .fs-headline { font-size: 6rem; }
 /*!!!
 
 # TYPOGRAPHY
@@ -3122,7 +3124,7 @@ http://tachyons.io/docs/debug-grid/
  .fr-s { float: right; _display: inline; }
  .fn-s { float: none; }
  .i-s { font-style: italic; }
- .fs-normal-s { font-style: normal; }
+ .fstyle-normal-s { font-style: normal; }
  .b-s { font-weight: bold; }
  .fw1-s { font-weight: 100; }
  .fw2-s { font-weight: 200; }
@@ -3374,14 +3376,16 @@ http://tachyons.io/docs/debug-grid/
  .ttl-s { text-transform: lowercase; }
  .ttu-s { text-transform: uppercase; }
  .ttn-s { text-transform: none; }
- .f0-s { font-size: 6rem; }
- .f1-s { font-size: 4rem; }
- .f2-s { font-size: 3rem; }
- .f3-s { font-size: 2rem; }
- .f4-s { font-size: 1.5rem; }
- .f5-s { font-size: 1rem; }
- .f6-s { font-size: .875rem; }
- .f7-s { font-size: .75rem; }
+ .fs1-s { font-size: .75rem; }
+ .fs2-s { font-size: .875rem; }
+ .fs3-s { font-size: 1rem; }
+ .fs4-s { font-size: 1.25rem; }
+ .fs5-s { font-size: 1.5rem; }
+ .fs6-s { font-size: 2.25rem; }
+ .fs7-s { font-size: 3rem; }
+ .fs8-s { font-size: 4rem; }
+ .fs9-s, .fs-subheadline-s { font-size: 5rem; }
+ .fs10-s, .fs-headline-s { font-size: 6rem; }
  .measure-s { max-width: 30em; }
  .measure-wide-s { max-width: 34em; }
  .measure-narrow-s { max-width: 20em; }
@@ -3550,7 +3554,7 @@ http://tachyons.io/docs/debug-grid/
  .fr-m { float: right; _display: inline; }
  .fn-m { float: none; }
  .i-m { font-style: italic; }
- .fs-normal-m { font-style: normal; }
+ .fstyle-normal-m { font-style: normal; }
  .b-m { font-weight: bold; }
  .fw1-m { font-weight: 100; }
  .fw2-m { font-weight: 200; }
@@ -3802,14 +3806,16 @@ http://tachyons.io/docs/debug-grid/
  .ttl-m { text-transform: lowercase; }
  .ttu-m { text-transform: uppercase; }
  .ttn-m { text-transform: none; }
- .f0-m { font-size: 6rem; }
- .f1-m { font-size: 4rem; }
- .f2-m { font-size: 3rem; }
- .f3-m { font-size: 2rem; }
- .f4-m { font-size: 1.5rem; }
- .f5-m { font-size: 1rem; }
- .f6-m { font-size: .875rem; }
- .f7-m { font-size: .75rem; }
+ .fs1-m { font-size: .75rem; }
+ .fs2-m { font-size: .875rem; }
+ .fs3-m { font-size: 1rem; }
+ .fs4-m { font-size: 1.25rem; }
+ .fs5-m { font-size: 1.5rem; }
+ .fs6-m { font-size: 2.25rem; }
+ .fs7-m { font-size: 3rem; }
+ .fs8-m { font-size: 4rem; }
+ .fs9-m, .fs-subheadline-m { font-size: 5rem; }
+ .fs10-m, .fs-headline-m { font-size: 6rem; }
  .measure-m { max-width: 30em; }
  .measure-wide-m { max-width: 34em; }
  .measure-narrow-m { max-width: 20em; }
@@ -3975,7 +3981,7 @@ http://tachyons.io/docs/debug-grid/
  .fr-l { float: right; _display: inline; }
  .fn-l { float: none; }
  .i-l { font-style: italic; }
- .fs-normal-l { font-style: normal; }
+ .fstyle-normal-l { font-style: normal; }
  .b-l { font-weight: bold; }
  .fw1-l { font-weight: 100; }
  .fw2-l { font-weight: 200; }
@@ -4227,14 +4233,16 @@ http://tachyons.io/docs/debug-grid/
  .ttl-l { text-transform: lowercase; }
  .ttu-l { text-transform: uppercase; }
  .ttn-l { text-transform: none; }
- .f0-l { font-size: 6rem; }
- .f1-l { font-size: 4rem; }
- .f2-l { font-size: 3rem; }
- .f3-l { font-size: 2rem; }
- .f4-l { font-size: 1.5rem; }
- .f5-l { font-size: 1rem; }
- .f6-l { font-size: .875rem; }
- .f7-l { font-size: .75rem; }
+ .fs1-l { font-size: .75rem; }
+ .fs2-l { font-size: .875rem; }
+ .fs3-l { font-size: 1rem; }
+ .fs4-l { font-size: 1.25rem; }
+ .fs5-l { font-size: 1.5rem; }
+ .fs6-l { font-size: 2.25rem; }
+ .fs7-l { font-size: 3rem; }
+ .fs8-l { font-size: 4rem; }
+ .fs9-l, .fs-subheadline-l { font-size: 5rem; }
+ .fs10-l, .fs-headline-l { font-size: 6rem; }
  .measure-l { max-width: 30em; }
  .measure-wide-l { max-width: 34em; }
  .measure-narrow-l { max-width: 20em; }


### PR DESCRIPTION
Expand font-size type scale to ten sizes, including `4rem` as well as all the sizes from Tachyons v4. Rename font-size classes to use `fs` prefix: `fs1`-`fs10`, with larger numbers for larger font sizes. Largest class `fs10` has alias `fs-headline`, and next largest class `fs9` has alias `fs-subheadline`.

Rename `fs-normal` class to `fstyle-normal`, so class naming is consistent: `fs` prefix for font-size, and `fstyle` prefix for font-style.

New class names are all different from Tachyons v4 class names, to avoid conflicting with legacy code.