### PR TITLE
Update seanoshea.me to https

### DIFF
--- a/sites.md
+++ b/sites.md
@@ -68,7 +68,7 @@
 * https://uptimeumbrella.com
 * http://www.talbs.me
 * https://podviaznikov.com
-* http://seanoshea.me
+* https://seanoshea.me
 * https://www.hiaida.com
 * http://maxogden.github.io/screencat/
 * http://numenta.com


### PR DESCRIPTION
Updating [seanoshea.me](https://seanoshea.me) from http to https after a redesign. Even though the HTML doesn't include tachyons classes directly, it relies on tachyons in [sass placeholder selector](https://sass-lang.com/documentation/style-rules/placeholder-selectors) format, which then [`@extend`](https://sass-lang.com/documentation/at-rules/extend) semantic class names using [`gulp-sass-extend-shorthand`](https://www.npmjs.com/package/gulp-sass-extend-shorthand). See the [main.scss](https://github.com/sposhe/sposhe.github.io/blob/gh-pages/src/scss/partials/%25main.scss) file in the project repo.